### PR TITLE
Fix fetching World Map Devices

### DIFF
--- a/Sources/SmartCitizen/Network/Models.swift
+++ b/Sources/SmartCitizen/Network/Models.swift
@@ -219,7 +219,7 @@ public struct WorldMapDevice: Codable, Hashable {
     let ownerId: Int
     let ownerUsername: String?
 
-    let kitId: Int
+    let kitId: Int?
 
     let latitude: Double?
     let longitude: Double?


### PR DESCRIPTION
When fetching devices for the World Map, decoding is failing.

It seems its possible that kit_id can be nil.
https://github.com/fablabbcn/smartcitizen-api/blob/7ac0f044ce59137f2317db3dfdfcf3e503f37d2f/app/views/v0/devices/_device.jbuilder#L46