### PR TITLE
Drive remaining views via viewModel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # ignore Xcode config files
 *.xcconfig
+.build/
 
 # General
 .DS_Store

--- a/SmartCitizen/SmartCitizenApp/SmartCitizenApp.swift
+++ b/SmartCitizen/SmartCitizenApp/SmartCitizenApp.swift
@@ -3,18 +3,26 @@ import SmartCitizen
 
 @main
 struct SmartCitizenApp: App {
+    let favoriteStore = FavoritesStore.default
     let deviceFetcher = DeviceFetcher(client: Client())
     let searchFetcher = SearchFetcher(client: Client())
     let mapFetcher = WorldMapFetcher(client: Client())
+    let settingsStore = SettingsStore()
+    let graphCache = SensorGraphXLabelCache()
 
     var body: some Scene {
         WindowGroup {
-            ContentView(mapViewModel: MapViewModel(region: .barcelona, fetcher: mapFetcher))
+            AppView()
+                .environmentObject(favoriteStore)
                 .environmentObject(deviceFetcher)
-                .environmentObject(searchFetcher)
-                .environmentObject(FavoritesStore())
-                .environmentObject(SettingsStore())
-                .environmentObject(SensorGraphXLabelCache())
+                .environmentObject(mapFetcher)
+                .environmentObject(settingsStore)
+                .environmentObject(graphCache)
+                .environmentObject(AppState(
+                    favoritesViewModel: .init(title: "Favorites", store: favoriteStore),
+                    mapViewModel: .init(region: .barcelona, fetcher: mapFetcher),
+                    searchViewModel: .init(fetcher: searchFetcher)
+                ))
         }
     }
 }

--- a/Sources/SmartCitizen/ContentView.swift
+++ b/Sources/SmartCitizen/ContentView.swift
@@ -2,12 +2,12 @@ import SwiftUI
 import Combine
 import MapKit
 
-final public class SensorGraphXLabelCache: ObservableObject {
+public final class SensorGraphXLabelCache: ObservableObject {
     public init(){}
     var cache = [String : CGFloat]()
 }
 
-public class AppState: ObservableObject {
+public final class AppState: ObservableObject {
     let favoritesViewModel: FavoritesViewModel
     let mapViewModel: MapViewModel
     let searchViewModel: SearchViewModel

--- a/Sources/SmartCitizen/ContentView.swift
+++ b/Sources/SmartCitizen/ContentView.swift
@@ -7,27 +7,43 @@ final public class SensorGraphXLabelCache: ObservableObject {
     var cache = [String : CGFloat]()
 }
 
-public struct ContentView: View {
+public class AppState: ObservableObject {
+    let favoritesViewModel: FavoritesViewModel
     let mapViewModel: MapViewModel
-    public init(mapViewModel: MapViewModel) {
+    let searchViewModel: SearchViewModel
+
+    public init(favoritesViewModel: FavoritesViewModel,
+                mapViewModel: MapViewModel,
+                searchViewModel: SearchViewModel) {
+        self.favoritesViewModel = favoritesViewModel
         self.mapViewModel = mapViewModel
+        self.searchViewModel = searchViewModel
     }
+
+}
+
+public struct AppView: View {
+
+    @EnvironmentObject
+    var appState: AppState
+
+    public init() {}
 
     public var body: some View {
         TabView {
-            FavoritesView()
+            FavoritesView(appState.favoritesViewModel)
                 .tabItem {
                     Image(systemName: "heart")
                     Text("Favorite Devices")
                 }
 
-            MapView(mapViewModel)
+            MapView(appState.mapViewModel)
                 .tabItem {
                     Image(systemName: "map")
                     Text("Map")
                 }
 
-            SearchView()
+            SearchView(appState.searchViewModel)
                 .tabItem {
                     Image(systemName: "magnifyingglass")
                     Text("Search Devices")
@@ -41,11 +57,12 @@ public struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
 
     static var previews: some View {
-        ContentView(mapViewModel: .init(region: .init(), fetcher: .mocked()))
-            .environmentObject(DeviceFetcher.mocked())
-            .environmentObject(SearchFetcher.mocked())
-            .environmentObject(FavoritesStore())
-            .environmentObject(SensorGraphXLabelCache())
+        AppView()
+            .environmentObject(AppState(
+                favoritesViewModel: .init(title: "Favorites", store: .mocked([DeviceCellModel]())),
+                mapViewModel: .init(region: .barcelona, fetcher: .mocked()),
+                searchViewModel: .init(fetcher: .mocked())
+            ))
     }
 }
 

--- a/Sources/SmartCitizen/Extensions/View+Extension.swift
+++ b/Sources/SmartCitizen/Extensions/View+Extension.swift
@@ -1,7 +1,0 @@
-import SwiftUI
-
-extension View {
-    public func eraseToAnyView() -> AnyView {
-        return AnyView(self)
-    }
-}

--- a/Sources/SmartCitizen/Network/APIRequestBuilder.swift
+++ b/Sources/SmartCitizen/Network/APIRequestBuilder.swift
@@ -33,7 +33,7 @@ enum APIRequestBuilder {
     }
 
     // Date is expected to be in UTC
-    static func readings(deviceId: Int,
+    static func readings(deviceID: Int,
                          sensorId: Int,
                          rollup: Rollup,
                          from fromDate: Date?,
@@ -65,7 +65,7 @@ enum APIRequestBuilder {
             queryItems.append(URLQueryItem(name: "all_intervals", value: allIntervals ? "true" : "false" ))
         }
 
-        return APIRequest(method: .get, path: "/v0/devices/\(deviceId)/readings/", queryParameter: queryItems)
+        return APIRequest(method: .get, path: "/v0/devices/\(deviceID)/readings/", queryParameter: queryItems)
     }
 
     ///  Searches Users, Devices, Tags and Cities at the same time

--- a/Sources/SmartCitizen/Network/Models.swift
+++ b/Sources/SmartCitizen/Network/Models.swift
@@ -75,7 +75,7 @@ public struct SCKMeasurement: Codable, Hashable {
 }
 
 public struct Sensor: Codable, Hashable {
-    let deviceId: Int
+    let deviceID: Int
     let sensorKey: String // "t"
     let sensorId: Int
     let componentId: Int

--- a/Sources/SmartCitizen/Preview Content/Mocks.swift
+++ b/Sources/SmartCitizen/Preview Content/Mocks.swift
@@ -50,6 +50,12 @@ extension SensorFetcher {
     }
 }
 
+extension FavoritesStore {
+    static func mocked(_ device: [DeviceCellModel]) -> FavoritesStore {
+        FavoritesStore(load: { device }, save: { _ in /* no-op */})
+    }
+}
+
 extension WorldMapFetcher {
     static func mocked() -> WorldMapFetcher {
         let data = NSDataAsset(name: "WorldDevices")!.data

--- a/Sources/SmartCitizen/Views/Device View/DeviceFetcher.swift
+++ b/Sources/SmartCitizen/Views/Device View/DeviceFetcher.swift
@@ -1,43 +1,28 @@
 import Foundation
 import Combine
 
-public enum DeviceFetchState {
-    case empty
-    case fetching
-    case fetched(DeviceViewModel)
-    case failed(Error)
-
-    var displayText: String {
-        switch self {
-        case .empty, .fetching:
-            return "Fetching..."
-        case .fetched(_):
-            return "Finished"
-        case let .failed(error):
-            return "Error: \(error.localizedDescription)"
-        }
-    }
-}
-
 public final class DeviceFetcher: ObservableObject {
-    @Published private(set)
-    public var state: DeviceFetchState = .empty
+    public struct DeviceAndMeasurements: Hashable, Identifiable, Codable {
+        public var id: Int { device.id }
+        public let device: Device
+        public let measurements: [SCKMeasurement]
+    }
 
-    let apiClient: Client
-    let cache: TimedCache<Int, DeviceViewModel>
+    private let apiClient: Client
+    private let cache: TimedCache<Int, DeviceAndMeasurements>
 
     public init(client: Client) {
         apiClient = client
-        cache = TimedCache<Int, DeviceViewModel>(name: "DeviceViewModels", interval: .minutes(10))
+        cache = TimedCache<Int, DeviceAndMeasurements>(name: "DeviceAndMeasurements", interval: .minutes(10))
     }
 
-    public func fetch(deviceID: Int) {
+    public func fetch(deviceID: Int) -> AnyPublisher<DeviceAndMeasurements, Error> {
         cache.deleteEntry(key: deviceID)
-        fetchIfNeeded(deviceID: deviceID)
+        return fetchIfNeeded(deviceID: deviceID)
     }
 
-    public func fetchIfNeeded(deviceID: Int) {
-        let cachePublisher: AnyPublisher<DeviceViewModel, Error> = cache.entryPublisher(key: deviceID)
+    public func fetchIfNeeded(deviceID: Int) -> AnyPublisher<DeviceAndMeasurements, Error> {
+        let cachePublisher: AnyPublisher<DeviceAndMeasurements, Error> = cache.entryPublisher(key: deviceID)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
 
@@ -47,22 +32,17 @@ public final class DeviceFetcher: ObservableObject {
         let deviceRequest = APIRequestBuilder.device(withId: deviceID)
         let devicePublisher = apiClient.publisher(for: deviceRequest)
 
-        let requestPublisher: AnyPublisher<DeviceViewModel, Error> = Publishers.Zip(measurementsPublisher, devicePublisher)
-            .map{ DeviceViewModel(device: $1, measurements: $0) }
-            .handleEvents(receiveSubscription: { [weak self] _ in
-                self?.state = .fetching
-            }, receiveOutput: { [weak self] value in
-                self?.cache.setEntry(key: value.id, value: value)
-            })
+        let requestPublisher: AnyPublisher<DeviceAndMeasurements, Error> = Publishers.Zip(measurementsPublisher, devicePublisher)
+            .map{ DeviceAndMeasurements(device: $1, measurements: $0) }
+            .handleEvents(
+                receiveOutput: { [unowned self] in self.cache.setEntry(key: $0.id, value: $0) }
+            )
             .eraseToAnyPublisher()
 
         // First check cache if stale or empty, do a request
-        cachePublisher
+        return cachePublisher
             .append(requestPublisher)
             .first()
-            .receive(on: DispatchQueue.main)
-            .map{ DeviceFetchState.fetched($0) }
-            .catch{ Just(DeviceFetchState.failed($0)) }
-            .assign(to: &$state)
+            .eraseToAnyPublisher()
     }
 }

--- a/Sources/SmartCitizen/Views/Device View/DeviceFetchingViewModel.swift
+++ b/Sources/SmartCitizen/Views/Device View/DeviceFetchingViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 import Combine
 
-public class DeviceFetchingViewModel: ObservableObject {
+public final class DeviceFetchingViewModel: ObservableObject {
     private var fetchSubscription: AnyCancellable?
 
     @ObservedObject

--- a/Sources/SmartCitizen/Views/Device View/DeviceFetchingViewModel.swift
+++ b/Sources/SmartCitizen/Views/Device View/DeviceFetchingViewModel.swift
@@ -1,0 +1,73 @@
+import Foundation
+import SwiftUI
+import Combine
+
+public class DeviceFetchingViewModel: ObservableObject {
+    private var fetchSubscription: AnyCancellable?
+
+    @ObservedObject
+    private var fetcher: DeviceFetcher
+
+    let deviceID: Int
+    let store: FavoritesStore
+
+    @Published
+    private(set) var isFavorite: Bool
+
+    @Published
+    private(set) var fetchingState: FetchingState
+
+    enum FetchingState {
+        case empty
+        case fetching(String)
+        case fetched(DeviceFetcher.DeviceAndMeasurements)
+        case failed(String)
+    }
+
+    public init(deviceID: Int, fetcher: DeviceFetcher, store: FavoritesStore) {
+        self.fetcher = fetcher
+        self.deviceID = deviceID
+        self.store = store
+        self.isFavorite = store.devices.contains{ $0.id == deviceID }
+        self.fetchingState = .empty
+    }
+
+    private func fetchDevice(with publisher: AnyPublisher<DeviceFetcher.DeviceAndMeasurements, Error>) {
+        fetchSubscription = publisher
+        .receive(on: DispatchQueue.main)
+        .handleEvents(receiveSubscription: { [unowned self] _ in
+            fetchingState = .fetching("Fetching...")
+        })
+        .map{ .fetched($0) }
+        .catch{ Just(.failed("Error: \($0.localizedDescription)")) }
+        .sink { [weak self] result in
+            self?.fetchingState = result
+        }
+    }
+
+    func pulledRefresh() {
+        let publisher = fetcher.fetch(deviceID: deviceID)
+        fetchDevice(with: publisher)
+    }
+
+    func viewAppeared() {
+        let publisher = fetcher.fetchIfNeeded(deviceID: deviceID)
+        fetchDevice(with: publisher)
+    }
+
+    func tappedFavoriteButton() {
+        let isStored = store.devices.contains{ $0.id == deviceID }
+        if isStored {
+            store.remove(withId: deviceID)
+            isFavorite = false
+        } else if case let .fetched(result) = fetchingState {
+            let device = result.device
+            let deviceModel = DeviceCellModel(id: device.id,
+                                              name: device.name,
+                                              cityName: device.data.location.city ?? "-",
+                                              userName: device.owner.username)
+            store.append(deviceModel)
+            isFavorite = true
+        }
+    }
+}

--- a/Sources/SmartCitizen/Views/Device View/DeviceView.swift
+++ b/Sources/SmartCitizen/Views/Device View/DeviceView.swift
@@ -1,27 +1,23 @@
 import SwiftUI
+import Combine
 
 public struct DeviceView: View {
 
-    @EnvironmentObject
-    var store: SettingsStore
-    
-    @State
-    var showingSettings = false
+    @ObservedObject
+    var viewModel: DeviceViewModel
 
     public init(device: DeviceViewModel) {
-        self.device = device
+        self.viewModel = device
     }
-
-    let device: DeviceViewModel
     
     var header: some View {
         HStack {
             Text("Device")
             Spacer()
-            Button(action: {showingSettings.toggle()}) {
+            Button(action: viewModel.settingsButtonTapped) {
                 Image(systemName: "gearshape")
             }
-            .sheet(isPresented: $showingSettings) {
+            .sheet(isPresented: $viewModel.showingSettings) {
                 SettingsView()
             }
         }
@@ -30,42 +26,42 @@ public struct DeviceView: View {
     public var body: some View {
         Form {
             Section(header: header) {
-                Text(device.name)
+                Text(viewModel.name)
                     .withLabel(label: "Name")
-                DateView(date: device.lastRecorded)
+                DateView(date: viewModel.lastRecorded)
                     .withLabel(label: "Updated")
 
-                if let aqi = device.aqi,
-                   store.shouldShowAqi {
+                if let aqi = viewModel.aqi,
+                   viewModel.store.shouldShowAqi {
                     AQIValueView(index: aqi)
                 }
 
-                if let thi = device.temperatureHumidityIndex,
-                   store.shouldShowThi {
+                if let thi = viewModel.temperatureHumidityIndex,
+                   viewModel.store.shouldShowThi {
                     THIValueView(thi: thi)
                 }
 
-                if let tdi = device.discomfortIndexAfterThom,
-                   store.shouldShowTdi {
+                if let tdi = viewModel.discomfortIndexAfterThom,
+                   viewModel.store.shouldShowTdi {
                     TDIValueView(tdi: tdi)
                 }
 
-                if let kdi = device.discomfortIndexAfterKawamura,
-                   store.shouldShowKdi {
+                if let kdi = viewModel.discomfortIndexAfterKawamura,
+                   viewModel.store.shouldShowKdi {
                     KDIValueView(kdi: kdi)
                 }
 
-                if let humidex = device.humidex,
-                   store.shouldShowHumidex {
+                if let humidex = viewModel.humidex,
+                   viewModel.store.shouldShowHumidex {
                     HumidexValueView(humidex: humidex)
                 }
             }
 
             Section(header: Text("Measurments")){
-                ForEach(device.measurments) { measurment in
+                ForEach(viewModel.measurments) { measurment in
                     let model = SensorChartViewModel(dateRange: .hour,
-                                                     sensor: SensorModel(sensor: measurment, device: self.device),
-                                                     timeZone: self.device.timeZone,
+                                                     sensor: SensorModel(sensor: measurment, device: viewModel),
+                                                     timeZone: viewModel.timeZone,
                                                      fetcher: SensorFetcher(client: Client()))
 
                     NavigationLink(destination: SensorChartView(model: model)) {
@@ -198,7 +194,8 @@ struct DeviceView_Previews: PreviewProvider {
         let measurements = PreviewData.loadMeasurements()
 
         let viewModel = DeviceViewModel(device: device,
-                                        measurements: measurements)
+                                        measurements: measurements,
+                                        store: .init())
         return NavigationView {
             DeviceView(device: viewModel)
         }

--- a/Sources/SmartCitizen/Views/Device View/DeviceViewModel.swift
+++ b/Sources/SmartCitizen/Views/Device View/DeviceViewModel.swift
@@ -2,8 +2,7 @@ import Foundation
 import CoreLocation
 import Combine
 
-
-public class DeviceViewModel: ObservableObject, Identifiable {
+public final class DeviceViewModel: ObservableObject, Identifiable {
     public let id: Int
     public let ownerName: String
     public let cityName: String

--- a/Sources/SmartCitizen/Views/Device View/DeviceViewModel.swift
+++ b/Sources/SmartCitizen/Views/Device View/DeviceViewModel.swift
@@ -1,9 +1,10 @@
 import Foundation
 import CoreLocation
+import Combine
 
-public struct DeviceViewModel: Hashable, Identifiable, Codable {
+
+public class DeviceViewModel: ObservableObject, Identifiable {
     public let id: Int
-
     public let ownerName: String
     public let cityName: String
 
@@ -84,27 +85,51 @@ public struct DeviceViewModel: Hashable, Identifiable, Codable {
 
         return Humidex(celsius: temperture, humidity: humidity)
     }
+
+    var store: SettingsStore
+
+    @Published
+    var showingSettings = false
+
+    public init(id: Int,
+                ownerName: String,
+                cityName: String,
+                name: String,
+                description: String,
+                state: String,
+                timeZone: TimeZone,
+                lastRecorded: Date,
+                measurments: [MeasurementViewModel],
+                store: SettingsStore) {
+        self.id = id
+        self.ownerName = ownerName
+        self.cityName = cityName
+        self.name = name
+        self.description = description
+        self.state = state
+        self.timeZone = timeZone
+        self.lastRecorded = lastRecorded
+        self.measurments = measurments
+        self.store = store
+    }
+
+    func settingsButtonTapped() {
+        showingSettings.toggle()
+    }
 }
 
 extension DeviceViewModel {
-    public init(device: Device, measurements:[SCKMeasurement]) {
-
+    public convenience init(device: Device, measurements: [SCKMeasurement], store: SettingsStore) {
         let measurementDict = Dictionary(uniqueKeysWithValues: measurements.map {($0.id, $0)})
+        let measurments: [MeasurementViewModel] = device.data.sensors
+            .map { (sensor: Device.DataObject.Sensor) in
+                let measurement = measurementDict[sensor.measurementId]
+                return MeasurementViewModel.init(sensor: sensor, measurement: measurement)
+            }
+            .sorted{ $0.name.lowercased() < $1.name.lowercased() }
 
-        id = device.id
-        name = device.name
-        ownerName = device.owner.username
-        cityName = device.data.location.city ?? "-"
-        description = device.description ?? "-"
-        state = device.state
-        lastRecorded = device.lastReadingAt ?? Date(timeIntervalSince1970: 0)
-        measurments = device.data.sensors.map { (sensor: Device.DataObject.Sensor) in
-            let measurement = measurementDict[sensor.measurementId]
-            return MeasurementViewModel.init(sensor: sensor, measurement: measurement)
-        }.sorted{ $0.name.lowercased() < $1.name.lowercased() }
-
-        timeZone = TimeZone.current
-        // TODO: Find a better way to find a correct TimeZone for the device
+        let timeZone = TimeZone.current
+        // TODO: Find a better way to get correct TimeZone for the device
 //        if let latitude = device.data.location.latitude,
 //           let longitude = device.data.location.longitude {
 //            let location = CLLocation(latitude: latitude, longitude: longitude)
@@ -114,5 +139,17 @@ extension DeviceViewModel {
 //                self.timeZone = placemark?.timeZone ?? TimeZone.init(secondsFromGMT: 0)!
 //            }
 //        }
+
+        self.init(id: device.id,
+                  ownerName: device.owner.username,
+                  cityName: device.data.location.city ?? "-",
+                  name: device.name,
+                  description: device.description ?? "-",
+                  state: device.state,
+                  timeZone: timeZone,
+                  lastRecorded: device.lastReadingAt ?? Date(timeIntervalSince1970: 0),
+                  measurments: measurments,
+                  store: store)
+
     }
 }

--- a/Sources/SmartCitizen/Views/Device View/SensorChart/SensorChartViewModel.swift
+++ b/Sources/SmartCitizen/Views/Device View/SensorChart/SensorChartViewModel.swift
@@ -103,7 +103,7 @@ final class SensorChartViewModel: ObservableObject {
 
     let fetcher: SensorFetcher
 
-    var deviceId: Int {
+    var deviceID: Int {
         sensor.device_id
     }
     var sensorId: Int{
@@ -241,7 +241,7 @@ final class SensorChartViewModel: ObservableObject {
     func fetch() {
         // overshoot by 2min, so we can capture the full range
         let interval = DateInterval(start: currentDateInterval.start, end: currentDateInterval.end.advanced(by: 120))
-        fetcher.requestReadingsFor(deviceId: deviceId, sensorId: sensorId, interval: interval, rollup: dateRange.rollup)
+        fetcher.requestReadingsFor(deviceID: deviceID, sensorId: sensorId, interval: interval, rollup: dateRange.rollup)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { [weak self] (completion: Subscribers.Completion<Error>) in
                 if case .failure(_) = completion {

--- a/Sources/SmartCitizen/Views/Device View/SensorChart/SensorFetcher.swift
+++ b/Sources/SmartCitizen/Views/Device View/SensorChart/SensorFetcher.swift
@@ -9,8 +9,8 @@ public struct SensorFetcher {
         apiClient = client
     }
     
-    public func requestReadingsFor(deviceId id: Int, sensorId: Int, interval: DateInterval, rollup: Rollup) ->  AnyPublisher<Readings, Error> {
-        let request = APIRequestBuilder.readings(deviceId: id,
+    public func requestReadingsFor(deviceID id: Int, sensorId: Int, interval: DateInterval, rollup: Rollup) ->  AnyPublisher<Readings, Error> {
+        let request = APIRequestBuilder.readings(deviceID: id,
                                                    sensorId: sensorId,
                                                    rollup: rollup,
                                                    from: interval.start,

--- a/Sources/SmartCitizen/Views/Favorites View/FavoritesView.swift
+++ b/Sources/SmartCitizen/Views/Favorites View/FavoritesView.swift
@@ -2,28 +2,40 @@ import Foundation
 import SwiftUI
 
 public struct FavoritesView: View {
-    public init() { }
+    @ObservedObject
+    var viewModel: FavoritesViewModel
 
-    @EnvironmentObject
-    var store: FavoritesStore
+    public init(_ viewModel: FavoritesViewModel) {
+        self.viewModel = viewModel
+    }
 
     public var body: some View {
         NavigationView {
-            DeviceListView(models: store.devices, title: "Favorite devices")
+            DeviceListView(
+                title: "Favorite devices",
+                devices: viewModel.storedDevices
+            )
         }
     }
 }
 
 public struct DeviceListView: View {
+    @EnvironmentObject
+    var deviceFetcher: DeviceFetcher
 
-    var models: [DeviceCellModel]
+    @EnvironmentObject
+    var favoritesStore: FavoritesStore
+
     let title: String
+    let devices: [DeviceCellModel]
 
     public var body: some View {
         List {
-            ForEach(models) { deviceModel in
-                NavigationLink(destination: DeviceFetchingView(deviceId: deviceModel.id)) {
-                    DeviceCell(model: deviceModel)
+            ForEach(devices) { device in
+                NavigationLink(destination: DeviceFetchingView.init(.init(deviceID: device.id,
+                                                                          fetcher: deviceFetcher,
+                                                                          store: favoritesStore))) {
+                    DeviceCell(model: device)
                 }
             }
         }
@@ -35,13 +47,13 @@ public struct DeviceListView: View {
 struct FavoritesView_Previews: PreviewProvider {
 
     static var previews: some View {
-        let models = [
+        let devices = [
             DeviceCellModel(id: 1, name: "Ludwig", cityName: "Fukuoka", userName: "Paul"),
             DeviceCellModel(id: 2, name: "Hackathon", cityName: "Fukuoka", userName: "Freddy"),
             DeviceCellModel(id: 3, name: "Muller", userName: "Hugo"),
         ]
         return NavigationView {
-            DeviceListView(models: models, title: "My List")
+            DeviceListView(title: "My List", devices: devices)
         }
     }
 }

--- a/Sources/SmartCitizen/Views/Favorites View/FavoritesViewModel.swift
+++ b/Sources/SmartCitizen/Views/Favorites View/FavoritesViewModel.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public class FavoritesViewModel: ObservableObject {
+    let title: String
+
+    @Published
+    var storedDevices = [DeviceCellModel]()
+
+    @Published
+    var store: FavoritesStore
+
+    public init(title: String, store: FavoritesStore) {
+        self.title = title
+        self.store = store
+
+        store.$devices.assign(to: &$storedDevices)
+    }
+}

--- a/Sources/SmartCitizen/Views/Favorites View/FavoritesViewModel.swift
+++ b/Sources/SmartCitizen/Views/Favorites View/FavoritesViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class FavoritesViewModel: ObservableObject {
+public final class FavoritesViewModel: ObservableObject {
     let title: String
 
     @Published

--- a/Sources/SmartCitizen/Views/Favorites View/SettingsStore.swift
+++ b/Sources/SmartCitizen/Views/Favorites View/SettingsStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-public class SettingsStore: ObservableObject {
+public final class SettingsStore: ObservableObject {
     public init() {}
     
     @AppStorage("shouldShowAqi")

--- a/Sources/SmartCitizen/Views/Search View/FetchState.swift
+++ b/Sources/SmartCitizen/Views/Search View/FetchState.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum FetchState<T: Equatable> {
+    case empty
+    case fetching
+    case fetched(T)
+    case failed(Error)
+}

--- a/Sources/SmartCitizen/Views/Search View/MapView.swift
+++ b/Sources/SmartCitizen/Views/Search View/MapView.swift
@@ -2,6 +2,11 @@ import SwiftUI
 import MapKit
 
 public struct MapView: View {
+    @EnvironmentObject
+    var deviceFetcher: DeviceFetcher
+
+    @EnvironmentObject
+    var store: FavoritesStore
 
     @ObservedObject
     var viewModel: MapViewModel
@@ -11,16 +16,24 @@ public struct MapView: View {
     }
 
     public var body: some View {
+        
         NavigationView {
             ZStack(alignment: .topLeading) {
                 NavigationLink(
-                    destination: DeviceFetchingView(deviceId: viewModel.selectedDeviceId),
+                    destination: DeviceFetchingView(
+                        DeviceFetchingViewModel(
+                            deviceID: viewModel.selectedDeviceId,
+                            fetcher: deviceFetcher,
+                            store: store
+                        )
+                    ),
                     tag: 1,
                     selection: $viewModel.actionState) {
                         EmptyView()
                     }
                 NavigationLink(
-                    destination: DeviceListView(models: viewModel.selectedDevices, title: "Devices"),
+                    destination: DeviceListView(title: "Devices",
+                                                devices: viewModel.selectedDevices),
                     tag: 2,
                     selection: $viewModel.actionState) {
                         EmptyView()
@@ -49,8 +62,13 @@ public struct MapView: View {
 
 #if DEBUG
 struct MapView_Previews: PreviewProvider {
+    static let deviceFetcher = DeviceFetcher.mocked()
+    static let favoritesStore = FavoritesStore.default
     static var previews: some View {
-        MapView(.init(region: .fukuoka, fetcher: WorldMapFetcher.mocked() ))
+        MapView(.init(region: .fukuoka, fetcher: .mocked()))
+        .environmentObject(deviceFetcher)
+        .environmentObject(favoritesStore)
     }
+
 }
 #endif

--- a/Sources/SmartCitizen/Views/Search View/MapViewModel.swift
+++ b/Sources/SmartCitizen/Views/Search View/MapViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import MapKit
 import Combine
 
-public class MapViewModel: ObservableObject {
+public final class MapViewModel: ObservableObject {
     let region: MKCoordinateRegion
 
     private let fetcher: WorldMapFetcher

--- a/Sources/SmartCitizen/Views/Search View/MapViewModel.swift
+++ b/Sources/SmartCitizen/Views/Search View/MapViewModel.swift
@@ -56,11 +56,11 @@ public class MapViewModel: ObservableObject {
 
         if annotations.count == 1,
            let annotation = annotations.first {
-            selectedDeviceId = annotation.deviceId
+            selectedDeviceId = annotation.deviceID
             actionState = 1
         } else {
             selectedDevices = annotations.map { annotation in
-                DeviceCellModel(id: annotation.deviceId,
+                DeviceCellModel(id: annotation.deviceID,
                                 name: annotation.title ?? "?",
                                 userName: annotation.subtitle ?? "?")
             }
@@ -82,7 +82,7 @@ public class MapViewModel: ObservableObject {
                       let longitude = device.longitude
                 else { return nil }
 
-                return SCKAnnotation(deviceId: device.id,
+                return SCKAnnotation(deviceID: device.id,
                                      title: device.name ?? "?",
                                      subtitle: device.systemTags.joined(separator: ", "),
                                      coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),

--- a/Sources/SmartCitizen/Views/Search View/SCKMapView/SCKAnnotation.swift
+++ b/Sources/SmartCitizen/Views/Search View/SCKMapView/SCKAnnotation.swift
@@ -7,8 +7,8 @@ class SCKAnnotation: NSObject, MKAnnotation, Identifiable {
         case sck21
     }
 
-    init(deviceId: Int, title: String, subtitle: String, coordinate: CLLocationCoordinate2D, type: SCKType) {
-        self.deviceId = deviceId
+    init(deviceID: Int, title: String, subtitle: String, coordinate: CLLocationCoordinate2D, type: SCKType) {
+        self.deviceID = deviceID
         self.title = title
         self.subtitle = subtitle
         self.coordinate = coordinate
@@ -17,7 +17,7 @@ class SCKAnnotation: NSObject, MKAnnotation, Identifiable {
         super.init()
     }
 
-    var deviceId: Int
+    var deviceID: Int
     var title: String?
     var subtitle: String?
     var coordinate: CLLocationCoordinate2D

--- a/Sources/SmartCitizen/Views/Search View/SCKMapView/SCKMapView.swift
+++ b/Sources/SmartCitizen/Views/Search View/SCKMapView/SCKMapView.swift
@@ -54,9 +54,9 @@ struct SCKMapView: UIViewRepresentable {
     func updateUIView(_ mapView: MKMapView, context: UIViewRepresentableContext<SCKMapView>) {
         let currentAnnotations: [SCKAnnotation] = mapView.annotations
             .compactMap { $0 as? SCKAnnotation }
-            .sorted { $0.deviceId < $1.deviceId }
+            .sorted { $0.deviceID < $1.deviceID }
 
-        let newAnnotations = annotations.sorted { $0.deviceId < $1.deviceId }
+        let newAnnotations = annotations.sorted { $0.deviceID < $1.deviceID }
 
         let diff = newAnnotations.difference(from: currentAnnotations)
 

--- a/Sources/SmartCitizen/Views/Search View/SearchFetcher.swift
+++ b/Sources/SmartCitizen/Views/Search View/SearchFetcher.swift
@@ -1,28 +1,6 @@
 import Foundation
 import Combine
 
-public enum FetchState<T: Equatable> {
-    case empty
-    case fetching
-    case fetched(T)
-    case failed(Error)
-}
-
-extension FetchState: Equatable {
-    public static func == (lhs: FetchState<T>, rhs: FetchState<T>) -> Bool {
-        switch (lhs, rhs) {
-        case (.empty, .empty), (.fetching, .fetching):
-            return true
-        case let (.fetched(lResult), .fetched(rResult)):
-            return lResult == rResult
-        case let (.failed(lError), .failed(rError)):
-            return lError.localizedDescription == rError.localizedDescription
-        default:
-            return false
-        }
-    }
-}
-
 public final class SearchFetcher: ObservableObject {
 
     @Published

--- a/Sources/SmartCitizen/Views/Search View/SearchResultView.swift
+++ b/Sources/SmartCitizen/Views/Search View/SearchResultView.swift
@@ -3,45 +3,37 @@ import SwiftUI
 struct SearchResultView: View {
     let result: GlobalSearch
 
-    var searchResult: AnyView {
+    var body: some View {
         switch result {
         case .user(let user):
-            return HStack {
+            HStack {
                 Text("User: ")
                 Text(user.username)
             }
-            .eraseToAnyView()
 
         case .device(let device):
             let model = DeviceCellModel(id: device.id,
                                         name: device.name ?? "?",
                                         cityName: device.city ?? "?",
                                         userName: device.ownerUsername ?? "?")
-            return DeviceCell(model: model)
-                .eraseToAnyView()
+            DeviceCell(model: model)
 
         case .city(let city):
-            return HStack {
+            HStack {
                 Text("City: ")
                 Text(city.city ?? "No Name")
             }
-            .eraseToAnyView()
+
         case .tag(let tag):
-            return HStack {
+            HStack {
                 Text("Tag: ")
                 Text(tag.name)
             }
-            .eraseToAnyView()
         case .unknown(let unknown):
-            return HStack {
+            HStack {
                 Text(unknown)
             }
-            .eraseToAnyView()
         }
-    }
-
-    var body: some View {
-        searchResult
     }
 }
 

--- a/Sources/SmartCitizen/Views/Search View/SearchViewModel.swift
+++ b/Sources/SmartCitizen/Views/Search View/SearchViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Combine
 
-public class SearchViewModel: ObservableObject{
+public final class SearchViewModel: ObservableObject{
 
     @Published
     var search: String = ""

--- a/Sources/SmartCitizen/Views/Search View/SearchViewModel.swift
+++ b/Sources/SmartCitizen/Views/Search View/SearchViewModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Combine
+
+public class SearchViewModel: ObservableObject{
+
+    @Published
+    var search: String = ""
+
+    let fetcher: SearchFetcher
+
+    @Published
+    private(set) var fetchingState: FetchingState
+
+    enum FetchingState {
+        case result([GlobalSearch])
+        case displayText(String)
+    }
+
+    public init(fetcher: SearchFetcher) {
+        self.fetcher = fetcher
+        self.fetchingState = .displayText("Search for devices.")
+
+        fetcher.$state
+            .map{ [unowned self] in self.translate($0) }
+            .assign(to: &$fetchingState)
+    }
+
+    private func translate(_ state: FetchState<[GlobalSearch]>) -> FetchingState {
+        switch state {
+        case .empty:
+            return .displayText("Search for devices.")
+        case .fetching:
+            return .displayText("Searching...")
+        case let .fetched(result):
+            return .result(result)
+        case let .failed(error):
+            return .displayText("Error: \(error.localizedDescription)")
+        }
+    }
+
+    func textinputHasChanged() {
+        fetcher.fetch(searchTerm: search)
+    }
+
+}


### PR DESCRIPTION
Use ViewModels to drive almost all Views. 
Removed usage of AnyView. Its neither efficient nor needed.